### PR TITLE
Use EmbeddedResource parameter to avoid requiring local samples

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -10,8 +10,6 @@ open Fake.ReleaseNotesHelper
 open System
 
 // --------------------------------------------------------------------------------------
-// START TODO: Provide project-specific details below
-// --------------------------------------------------------------------------------------
 
 // Information about the project are used
 //  - for version and project name in generated AssemblyInfo file
@@ -48,8 +46,6 @@ let gitHome = "https://github.com/evelinag"
 // The name of the project on GitHub
 let gitName = "FSharp.Data.Toolbox"
 
-// --------------------------------------------------------------------------------------
-// END TODO: The rest of the file includes standard build steps 
 // --------------------------------------------------------------------------------------
 
 // Read additional information from the release notes document

--- a/src/FSharp.Data.Toolbox.Twitter/FSharp.Data.Toolbox.Twitter.fsproj
+++ b/src/FSharp.Data.Toolbox.Twitter/FSharp.Data.Toolbox.Twitter.fsproj
@@ -53,6 +53,27 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="json/bearer_token.json">
+      <Link>json/bearer_token.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/stream.json">
+      <Link>json/stream.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/friendship_show.json">
+      <Link>json/friendship_show.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/idslist.json">
+      <Link>json/idslist.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/search_tweets.json">
+      <Link>json/search_tweets.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/timeline.json">
+      <Link>json/timeline.json</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="json/users_lookup.json">
+      <Link>json/users_lookup.json</Link>
+    </EmbeddedResource>
     <Compile Include="../Common/AssemblyInfo.fs">
       <Link>AssemblyInfo.fs</Link>
     </Compile>

--- a/src/FSharp.Data.Toolbox.Twitter/Twitter.fs
+++ b/src/FSharp.Data.Toolbox.Twitter/Twitter.fs
@@ -16,13 +16,13 @@ open FSharp.WebBrowser
 
 // ----------------------------------------------------------------------------------------------
 
-module Utils = 
+module internal Utils = 
   let requestTokenURI = "https://api.twitter.com/oauth/request_token"
   let accessTokenURI = "https://api.twitter.com/oauth/access_token"
   let authorizeURI = "https://api.twitter.com/oauth/authorize"
   let appOnlyTokenURI = "https://api.twitter.com/oauth2/token"
 
-  type Response = JsonProvider<"json/bearer_token.json">
+  type Response = JsonProvider<"json/bearer_token.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,bearer_token.json">
 
   // Utilities
   let unreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
@@ -233,12 +233,12 @@ module WebRequestExtensions =
 // ----------------------------------------------------------------------------------------------
 
 module TwitterTypes = 
-  type Tweet = JsonProvider<"json/stream.json", SampleIsList=true>
-  type TimeLine = JsonProvider<"json/timeline.json">
-  type SearchTweets = JsonProvider<"json/search_tweets.json">
-  type IdsList = JsonProvider<"json/idslist.json">
-  type UsersLookup = JsonProvider<"json/users_lookup.json">
-  type FriendshipShow = JsonProvider<"json/friendship_show.json">
+  type Tweet = JsonProvider<"json/stream.json", SampleIsList=true, EmbeddedResource="FSharp.Data.Toolbox.Twitter,stream.json">
+  type TimeLine = JsonProvider<"json/timeline.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,timeline.json">
+  type SearchTweets = JsonProvider<"json/search_tweets.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,search_tweets.json">
+  type IdsList = JsonProvider<"json/idslist.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,idslist.json">
+  type UsersLookup = JsonProvider<"json/users_lookup.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,users_lookup.json">
+  type FriendshipShow = JsonProvider<"json/friendship_show.json", EmbeddedResource="FSharp.Data.Toolbox.Twitter,friendship_show.json">
 
 type TwitterConnector =
   abstract Connect : string -> Twitter 

--- a/tests/FSharp.Data.Toolbox.Twitter.Tests/Tests.fs
+++ b/tests/FSharp.Data.Toolbox.Twitter.Tests/Tests.fs
@@ -1,6 +1,8 @@
 ﻿#if INTERACTIVE
 #I "../../packages/FSharp.Data.2.0.5/lib/net40"
 #I "../../bin"
+#I "../../packages/NUnit.2.6.3/lib"
+#r "nunit.framework.dll"
 #r @"FSharp.Data.dll"
 #r "FSharp.Data.Toolbox.Twitter.dll"
 open FSharp.Data.Toolbox.Twitter
@@ -13,8 +15,9 @@ open FSharp.Data.Toolbox.Twitter
 open NUnit.Framework
 
 [<Test>]
-let ``Can authenticate with Twitter using AppOnly mode`` () =
+let ``Can authenticate with Twitter using AppOnly mode and search for F# org twitter`` () =
   let key = "mKQL29XNemjQbLlQ8t0pBg"
   let secret = "T27HLDve1lumQykBUgYAbcEkbDrjBe6gwbu0gqi4saM"
   let twitter = Twitter.AuthenticateAppOnly(key, secret)
-  Assert.AreSame(1, 2)
+  let actual = twitter.Users.Lookup ["fsharporg"] |> Seq.head
+  Assert.IsTrue(actual.Id = 880772426L)


### PR DESCRIPTION
This uses a new feature of F# Data here: https://github.com/fsharp/FSharp.Data/pull/599

(It'll start working after a new version of F# Data is released - then we'll also need to update the `FSharp.Data` NuGet reference in this project to a new version.)
