### PR TITLE
RLE decompression bugfix

### DIFF
--- a/src/FSharp.Data.Toolbox.Sas/Core.fs
+++ b/src/FSharp.Data.Toolbox.Sas/Core.fs
@@ -299,7 +299,8 @@ module Core =
                             resultIndex <- resultIndex + 1
                         srcIndex <- srcIndex + 1
                     | 0x70uy ->
-                        for z = 0 to copyOffset + 16 do
+                        for z = 0 to firstByteEnd*256 + 
+                            copyOffset + 16 do
                             result.[resultIndex] <- 0uy
                             resultIndex <- resultIndex + 1
                         srcIndex <- srcIndex + 1


### PR DESCRIPTION
Replication of a bugfix made to the equivalent Python library: https://bitbucket.org/jaredhobbs/sas7bdat/commits/0554f445e071c3c7ee87d53f0271ac99e1728a34 (line 135)