### PR TITLE
Bugfix: exception when date is encoded with less than 8 bytes

### DIFF
--- a/src/FSharp.Data.Toolbox.Sas/Core.fs
+++ b/src/FSharp.Data.Toolbox.Sas/Core.fs
@@ -299,7 +299,8 @@ module Core =
                             resultIndex <- resultIndex + 1
                         srcIndex <- srcIndex + 1
                     | 0x70uy ->
-                        for z = 0 to copyOffset + 16 do
+                        for z = 0 to firstByteEnd*256 + 
+                            copyOffset + 16 do
                             result.[resultIndex] <- 0uy
                             resultIndex <- resultIndex + 1
                         srcIndex <- srcIndex + 1


### PR DESCRIPTION
SAS allows encoding dates with less than 8 bytes (e.g. with 4 bytes), however ToDate/ToDateTime always expected exactly 8 bytes. 
The Python script already handles such cases.