### PR TITLE
Adding an option to use a dev-generated token.

### DIFF
--- a/src/FSharp.Data.Toolbox.Twitter/Twitter.fs
+++ b/src/FSharp.Data.Toolbox.Twitter/Twitter.fs
@@ -13,7 +13,6 @@ open FSharp.Data
 open FSharp.Control
 open FSharp.WebBrowser
 
-
 // ----------------------------------------------------------------------------------------------
 
 module internal Utils = 
@@ -231,7 +230,6 @@ module WebRequestExtensions =
       | UserContext {ConsumerKey = ck; ConsumerSecret = cs; AccessToken = ack; AccessSecret = acs} ->
           Utils.addAuthHeaderForUser this originalUrl ck cs ack acs queryParams
 
-
 // ----------------------------------------------------------------------------------------------
 
 module TwitterTypes = 
@@ -438,6 +436,14 @@ and Twitter(context:TwitterContext) =
   static member AuthenticateAppOnly (consumer_key, consumer_secret) =
     let token = Utils.requestAppOnlyToken consumer_key consumer_secret
     Twitter(AppContext { AppOnlyToken = token })
+
+  static member AuthenticateAppSingleUser (consumer_key, consumer_secret, access_token, access_secret) = 
+    Twitter(
+      UserContext { 
+              ConsumerKey = consumer_key;
+              ConsumerSecret = consumer_secret;
+              AccessToken = access_token;
+              AccessSecret = access_secret; })
 
   member twitter.Timelines = Timelines(context)
   member twitter.Streaming = Streaming(context)


### PR DESCRIPTION
Twitter has an option to generate a token from the site that just accesses your own account (https://dev.twitter.com/oauth/overview). I just added a call to be able to use it. 