### PR TITLE
adding YYMMDDN

### DIFF
--- a/src/FSharp.Data.Toolbox.Sas/Signatures.fs
+++ b/src/FSharp.Data.Toolbox.Sas/Signatures.fs
@@ -162,7 +162,7 @@ module SasSignatures =
     let TIME_FORMAT_STRINGS = "TIME"
     [<Literal>]
     let DATE_TIME_FORMAT_STRINGS = "DATETIME"
-    let DATE_FORMAT_STRINGS = ["YYMMDD"; "MMDDYY"; "DDMMYY"; "DATE"; "JULIAN"; "MONYY"]
+    let DATE_FORMAT_STRINGS = ["YYMMDDN";"YYMMDD"; "MMDDYY"; "DDMMYY"; "DATE"; "JULIAN"; "MONYY"]
 
     [<Literal>]
     let RLE_COMPRESSION = "SASYZCRL"


### PR DESCRIPTION
Adding a Date format so that the Type Provider will parse Dates in SAS files with columns in format "YYMMDDN". Previously, the provider would simply return the integer representing the date.

A full list of date formats is here: https://v8doc.sas.com/sashtml/lrcon/zenid-63.htm

I just added the format I needed in my file, because I could check and verify my simple change worked.